### PR TITLE
Fix tf2c server run

### DIFF
--- a/team-fortress2-classifiedupdates.json
+++ b/team-fortress2-classifiedupdates.json
@@ -190,5 +190,5 @@
         "UpdateSource": "SteamCMD",
         "UpdateSourceData": "3557020",
         "SkipOnFailure": false
-    }
+    },
 ]

--- a/team-fortress2-classifiedupdates.json
+++ b/team-fortress2-classifiedupdates.json
@@ -190,12 +190,5 @@
         "UpdateSource": "SteamCMD",
         "UpdateSourceData": "3557020",
         "SkipOnFailure": false
-    },
-    {
-        "UpdateStageName": "TF2 Classic Library Fixes",
-        "UpdateSourcePlatform": "Linux",
-        "UpdateSource": "Executable",
-        "UpdateSourceData": "/bin/bash",
-        "UpdateSourceArgs": "-c \"cd tf2c/3557020/bin/linux64 && rm -f libvstdlib.so && ln -sf libvstdlib_srv.so libvstdlib.so && cd ../.. && cd tf2classified/bin/linux64 && ln -sf server.so server_srv.so && mkdir -p ~/.steam/sdk64 && cd ../../../ && ln -sf tf2classified/bin/linux64/steamclient.so ~/.steam/sdk64/steamclient.so\""
     }
 ]

--- a/team-fortress2-classifiedupdates.json
+++ b/team-fortress2-classifiedupdates.json
@@ -196,6 +196,6 @@
         "UpdateSourcePlatform": "Linux",
         "UpdateSource": "Executable",
         "UpdateSourceData": "/bin/bash",
-        "UpdateSourceArgs": "-c \"cd tf2c/3557020/bin/linux64 && rm -f libvstdlib.so && ln -sf libvstdlib_srv.so libvstdlib.so && cd ../.. && cd tf2classified/bin/linux64 && ln -sf server.so server_srv.so && mkdir -p ~/.steam/sdk64 && cd ../../../ && ln -sf linux64/steamclient.so ~/.steam/sdk64/\""
+        "UpdateSourceArgs": "-c \"cd tf2c/3557020/bin/linux64 && rm -f libvstdlib.so && ln -sf libvstdlib_srv.so libvstdlib.so && cd ../.. && cd tf2classified/bin/linux64 && ln -sf server.so server_srv.so && mkdir -p ~/.steam/sdk64 && cd ../../../ && ln -sf tf2classified/bin/linux64/steamclient.so ~/.steam/sdk64/steamclient.so\""
     }
 ]


### PR DESCRIPTION
Silent update of their doc removed the part about needing to patch the .so files for linux.

Old instructions (image based of that https://web.archive.org/web/20260130190311/https://wiki.tf2classic.com/wiki/Dedicated_Linux_server)

New instructions https://wiki.tf2classic.com/wiki/Dedicated_Linux_server (noticed removed the patching of so files)


# How to update affected instance

Go to Configuration -> Instance Deployement -> Instance Management.

Click on the button "Fetch Latest"

Now go to your instances, click on the Update icon (INSTANCE LIST PAGE, NOT PER INSTANCE, beside the share instance buttons, ...)  to update them to latest changes.

Now click update on the instance where the tf2c server is to update appids.

Now the server should be fixed.

NOTE: if you see 13 steps for the update, it means the update did not apply to your instance.